### PR TITLE
#6 [PhantomCope] config.ymlから有効時間を指定できるようにした

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+services:
+  # PhantomCopeService
+  # ファントムの追跡から逃れるための機能まとめ
+  phantomCopeService:
+    # 効果が有効なTick数
+    tick: 1000

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,10 @@ permissions:
     default: op
     children:
       ymze.phantomcoping: true
+      ymze.central.reload: true
   ymze.phantomcoping:
     default: true
     description: Player can cope phantoms by consuming rotten flesh
+  ymze.central.reload:
+    default: op
+    description: reload config.yml

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -1,7 +1,8 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Central, PhantomCopeService}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.Service
+import org.bukkit.command.{Command, CommandSender}
 import org.bukkit.plugin.java.JavaPlugin
 
 class Main extends JavaPlugin {
@@ -13,6 +14,17 @@ class Main extends JavaPlugin {
 
   override def onEnable(): Unit = {
     services.foreach(_._2.registerListeners())
+  }
+
+  override def onCommand(sender: CommandSender, command: Command, label: String, args: Array[String]): Boolean = {
+    (for {
+      subCommand <- args.headOption
+      service <- services.get(subCommand)
+    } yield (subCommand, service)) match {
+      case Some((_, service)) => service.onCommand(sender, args.toList.tail)
+      case None => services.get(Central.NAME).foreach(_.onCommand(sender, args.toList.tail))
+    }
+    super.onCommand(sender, command, label, args)
   }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -1,6 +1,7 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Central, PhantomCopeService}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.central.Central
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.Service
 import org.bukkit.command.{Command, CommandSender}
 import org.bukkit.plugin.java.JavaPlugin

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -25,7 +25,7 @@ class Main extends JavaPlugin {
       case Some((_, service)) => service.onCommand(sender, args.toList.tail)
       case None => services.get(Central.NAME).foreach(_.onCommand(sender, args.toList))
     }
-    super.onCommand(sender, command, label, args)
+    true
   }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -14,6 +14,7 @@ class Main extends JavaPlugin {
   ).map(service => (service.name, service)).toMap
 
   override def onEnable(): Unit = {
+    saveDefaultConfig()
     services.foreach(_._2.registerListeners())
   }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -1,12 +1,12 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
-import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{ListenerContainer, Service}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.Service
 import org.bukkit.plugin.java.JavaPlugin
 
 class Main extends JavaPlugin {
   implicit val self: Main = this
-  lazy val services: Seq[Service with ListenerContainer] = Seq(
+  lazy val services: Seq[Service] = Seq(
     new PhantomCopeService
   )
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -6,12 +6,13 @@ import org.bukkit.plugin.java.JavaPlugin
 
 class Main extends JavaPlugin {
   implicit val self: Main = this
-  lazy val services: Seq[Service] = Seq(
-    new PhantomCopeService
-  )
+  lazy val services: Map[String, Service] = Seq(
+    new PhantomCopeService,
+    new Central
+  ).map(service => (service.name, service)).toMap
 
   override def onEnable(): Unit = {
-    services.foreach(_.registerListeners())
+    services.foreach(_._2.registerListeners())
   }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/Main.scala
@@ -23,7 +23,7 @@ class Main extends JavaPlugin {
       service <- services.get(subCommand)
     } yield (subCommand, service)) match {
       case Some((_, service)) => service.onCommand(sender, args.toList.tail)
-      case None => services.get(Central.NAME).foreach(_.onCommand(sender, args.toList.tail))
+      case None => services.get(Central.NAME).foreach(_.onCommand(sender, args.toList))
     }
     super.onCommand(sender, command, label, args)
   }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
@@ -17,12 +17,17 @@ class Central(implicit main: Main) extends Service {
 
   override def onCommand(sender: CommandSender, args: List[String]): Unit = {
     args.headOption.foreach {
-      case "reload" => {
+      case "reload" =>
         Try(sender.asInstanceOf[Player]).toOption match {
-          case Some(player) if player.hasPermission("ymze.central.reload") => reloadConfig()
-          case None => reloadConfig()
+          case Some(player) if player.hasPermission("ymze.central.reload") => {
+            reloadConfig()
+            player.sendMessage("reload config")
+          }
+          case None => {
+            sender.sendMessage("[YmzeCentra] reload config")
+            reloadConfig()
+          }
         }
-      }
     }
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
@@ -1,4 +1,4 @@
-package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
+package dev.ekuinox.IntegrativeYmzeServerPlugin.services.central
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.Main
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/central/Central.scala
@@ -2,6 +2,10 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.central
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.Main
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+import scala.util.Try
 
 /**
  * プラグイン自体の管理だとかそういうのをやる
@@ -10,6 +14,17 @@ class Central(implicit main: Main) extends Service {
   import Central._
   override val name: String = NAME
   override val eventListeners: Seq[EventListener] = Seq.empty
+
+  override def onCommand(sender: CommandSender, args: List[String]): Unit = {
+    args.headOption.foreach {
+      case "reload" => {
+        Try(sender.asInstanceOf[Player]).toOption match {
+          case Some(player) if player.hasPermission("ymze.central.reload") => reloadConfig()
+          case None => reloadConfig()
+        }
+      }
+    }
+  }
 }
 
 object Central {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Central.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Central.scala
@@ -1,0 +1,13 @@
+package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
+
+import dev.ekuinox.IntegrativeYmzeServerPlugin.Main
+import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}
+
+/**
+ * プラグイン自体の管理だとかそういうのをやる
+ */
+class Central(implicit main: Main) extends Service {
+  override val name: String = "central"
+  override val eventListeners: Seq[EventListener] = Seq.empty
+
+}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Central.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Central.scala
@@ -7,7 +7,11 @@ import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}
  * プラグイン自体の管理だとかそういうのをやる
  */
 class Central(implicit main: Main) extends Service {
-  override val name: String = "central"
+  import Central._
+  override val name: String = NAME
   override val eventListeners: Seq[EventListener] = Seq.empty
+}
 
+object Central {
+  val NAME = "central"
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -1,0 +1,18 @@
+package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
+
+import scala.language.implicitConversions
+
+object Configure {
+
+  class ServiceWithConfigure(service: PhantomCopeService) {
+    private val configure = service.getPlugin.getConfig
+
+    /**
+     * 回避を開始して効果が無効になるまでの時間(tick)
+     * @return Long
+     */
+    def getActiveCopingTicks: Long = configure.getLong(service.makeConfigurePath("tick"), 1000)
+  }
+  implicit def convertToServiceWithConfigure(service: PhantomCopeService): ServiceWithConfigure = new ServiceWithConfigure(service)
+
+}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/PhantomCopeService.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/PhantomCopeService.scala
@@ -1,14 +1,14 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners.{EntityTargetEventListener, PlayerItemConsumeEventListener}
-import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, ListenerContainer, Service}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.{Main => Plugin}
 
 /**
  * ファントムの寄ってくるのが鬱陶しいので、寄ってこないようにする
  * @param plugin Plugin
  */
-class PhantomCopeService(implicit plugin: Plugin) extends Service with ListenerContainer{
+class PhantomCopeService(implicit plugin: Plugin) extends Service {
   implicit val self: PhantomCopeService = this
 
   override val name = "phantomCopeService"

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -2,16 +2,13 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
 import org.bukkit.persistence.PersistentDataType
 import collection.mutable.{Map => MutableMap}
+import Configure._
 
 object Timer {
   private type BukkitPlayer = org.bukkit.entity.Player
 
   val NAMESPACED_KEY = "timer"
   val DATA_TYPE: PersistentDataType[String, String] = PersistentDataType.STRING
-
-  // 機能の有効Tick数
-  val ACTIVE_TICKS = 1000
-
   val timers: collection.mutable.Map[BukkitPlayer, Runner] = MutableMap[BukkitPlayer, Runner]()
 
   class Player(player: BukkitPlayer)(implicit service: PhantomCopeService) {
@@ -32,7 +29,7 @@ object Timer {
       timers.get(player).foreach(_.cancel())
       val runner = new Runner(player)
       timers += (player -> runner)
-      runner.runTaskLaterAsynchronously(service.getPlugin, ACTIVE_TICKS)
+      runner.runTaskLaterAsynchronously(service.getPlugin, service.getActiveCopingTicks)
       player.sendMessage(s"${player.getDisplayName} activate coping")
     }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
@@ -15,7 +15,8 @@ class EntityTargetEventListener(implicit service: PhantomCopeService) extends Ev
   def onEntityTarget(event: EntityTargetEvent): Unit = {
     for {
       phantom <- event.getEntity.asPhantom
-      player <- event.getTarget.asPlayer
+      target <- Option(event.getTarget)
+      player <- target.asPlayer
     } {
       event.setCancelled(player.canCope)
     }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
@@ -7,6 +7,8 @@ import org.bukkit.entity.EntityType._
 import org.bukkit.event.EventHandler
 import org.bukkit.event.entity.EntityTargetEvent
 
+import scala.util.Try
+
 class EntityTargetEventListener(implicit service: PhantomCopeService) extends EventListener {
   import EntityTargetEventListener._
   import ImplicitConversions._
@@ -27,10 +29,10 @@ object EntityTargetEventListener {
   implicit class EntityExtends(entity: Entity) {
     // for Phantom
     def isPhantom: Boolean = entity.getType == PHANTOM
-    def asPhantom: Option[Phantom] = if (isPhantom) Some(entity.asInstanceOf[Phantom]) else None
+    def asPhantom: Option[Phantom] = if (isPhantom) Try(entity.asInstanceOf[Phantom]).toOption else None
 
     // for Player
     def isPlayer: Boolean = entity.getType == PLAYER
-    def asPlayer: Option[Player] = if (isPlayer) Some(entity.asInstanceOf[Player]) else None
+    def asPlayer: Option[Player] = if (isPlayer) Try(entity.asInstanceOf[Player]).toOption else None
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/ListenerContainer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/ListenerContainer.scala
@@ -1,9 +1,0 @@
-package dev.ekuinox.IntegrativeYmzeServerPlugin.utils
-
-/**
- * ServiceでEventListenerを管理しやすくしたい気持ち
- */
-trait ListenerContainer {
-  val eventListeners: Seq[EventListener]
-  def registerListeners(): Unit = eventListeners.foreach(_.register())
-}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -32,6 +32,6 @@ abstract class Service(implicit val main: Main) {
    */
   val subCommand: String = name
 
-  def onCommand(sender: CommandSender, args: Array[String]): Unit = {}
+  def onCommand(sender: CommandSender, args: List[String]): Unit = {}
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -14,9 +14,9 @@ abstract class Service(implicit val main: Main) {
   /**
    * config 管理
    */
-  val configurePath = s"services.$name"
+  lazy val configurePath = s"services.$name"
 
-  def makeConfigurePath(key: String): String = s"$configurePath.$key"
+  def makeConfigurePath(key: String): String = s"services.$name.$key"
 
   def reloadConfig(): Unit = main.reloadConfig()
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -19,4 +19,11 @@ abstract class Service(implicit val main: Main) {
 
   def reloadConfig(): Unit = main.reloadConfig()
 
+  /**
+   * Listener 管理
+   */
+  val eventListeners: Seq[EventListener]
+
+  def registerListeners(): Unit = eventListeners.foreach(_.register())
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -12,4 +12,6 @@ abstract class Service(implicit val main: Main) {
 
   val configurePath = s"services.$name"
 
+  def makeConfigurePath(key: String): String = s"$configurePath.$key"
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -9,4 +9,7 @@ abstract class Service(implicit val main: Main) {
   def makeNamespacedKey(key: String): NamespacedKey = new NamespacedKey(main, s"$name.key")
 
   val name: String
+
+  val configurePath = s"services.$name"
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -2,6 +2,7 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.utils
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.Main
 import org.bukkit.NamespacedKey
+import org.bukkit.command.CommandSender
 
 abstract class Service(implicit val main: Main) {
   val name: String
@@ -25,5 +26,12 @@ abstract class Service(implicit val main: Main) {
   val eventListeners: Seq[EventListener]
 
   def registerListeners(): Unit = eventListeners.foreach(_.register())
+
+  /**
+   * command 管理
+   */
+  val subCommand: String = name
+
+  def onCommand(sender: CommandSender, args: Array[String]): Unit = {}
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -14,4 +14,6 @@ abstract class Service(implicit val main: Main) {
 
   def makeConfigurePath(key: String): String = s"$configurePath.$key"
 
+  def reloadConfig(): Unit = main.reloadConfig()
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/utils/Service.scala
@@ -4,12 +4,15 @@ import dev.ekuinox.IntegrativeYmzeServerPlugin.Main
 import org.bukkit.NamespacedKey
 
 abstract class Service(implicit val main: Main) {
+  val name: String
+
   def getPlugin: Main = main
 
   def makeNamespacedKey(key: String): NamespacedKey = new NamespacedKey(main, s"$name.key")
 
-  val name: String
-
+  /**
+   * config 管理
+   */
   val configurePath = s"services.$name"
 
   def makeConfigurePath(key: String): String = s"$configurePath.$key"


### PR DESCRIPTION
fix #6

`config.yml`を扱うために結構いろいろ書いた
Tickを指定するパス => `services.phantomCopeService.tick`
