### PR TITLE
#5 [PhantomCope] config.ymlで対象にするアイテムを複数指定できるように

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,3 +4,6 @@ services:
   phantomCopeService:
     # 効果が有効なTick数
     tick: 1000
+    items:
+      - ROTTEN_FLESH # ゾンビ肉
+      - POISONOUS_POTATO # 青芋

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -11,15 +11,17 @@ object Configure {
   implicit class ServiceWithConfigure(service: PhantomCopeService) {
     private val configure = service.getPlugin.getConfig
 
+    private def makeKey(key: String): String = service.makeConfigurePath(key)
+
     /**
      * 回避を開始して効果が無効になるまでの時間(tick)
      * @return Long
      */
-    def getActiveCopingTicks: Long = configure.getLong(service.makeConfigurePath("tick"), 1000)
+    def getActiveCopingTicks: Long = configure.getLong(makeKey("tick"), 1000)
 
     /**
      * 対象にするMaterialのリスト
      */
-    def getTargetItems: List[Material] = configure.getStringList("items").asScala.flatMap(name => Try(Material.valueOf(name)).toOption).toList
+    def getTargetItems: List[Material] = configure.getStringList(makeKey("items")).asScala.flatMap(name => Try(Material.valueOf(name)).toOption).toList
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 object Configure {
 
-  class ServiceWithConfigure(service: PhantomCopeService) {
+  implicit class ServiceWithConfigure(service: PhantomCopeService) {
     private val configure = service.getPlugin.getConfig
 
     /**
@@ -13,6 +13,4 @@ object Configure {
      */
     def getActiveCopingTicks: Long = configure.getLong(service.makeConfigurePath("tick"), 1000)
   }
-  implicit def convertToServiceWithConfigure(service: PhantomCopeService): ServiceWithConfigure = new ServiceWithConfigure(service)
-
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -1,6 +1,10 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
+import org.bukkit.Material
+
 import scala.language.implicitConversions
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 object Configure {
 
@@ -12,5 +16,10 @@ object Configure {
      * @return Long
      */
     def getActiveCopingTicks: Long = configure.getLong(service.makeConfigurePath("tick"), 1000)
+
+    /**
+     * 対象にするMaterialのリスト
+     */
+    def getTargetItems: List[Material] = configure.getStringList("items").asScala.flatMap(name => Try(Material.valueOf(name)).toOption).toList
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/ImplicitConversions.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/ImplicitConversions.scala
@@ -1,7 +1,0 @@
-package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
-
-object ImplicitConversions {
-  implicit def toPermissionPlayer(player: org.bukkit.entity.Player): Permissions.Player = new Permissions.Player(player)
-  implicit def toTimerPlayer(player: org.bukkit.entity.Player)(implicit service: PhantomCopeService): Timer.Player = new Timer.Player(player)
-
-}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Permissions.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Permissions.scala
@@ -1,13 +1,15 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
+import org.bukkit.entity.Player
+
 object Permissions {
 
   private val COPING = "ymze.phantomcoping"
 
-  class Player(player: org.bukkit.entity.Player) {
+  implicit class PlayerWithPermission(player: Player) {
 
     def hasCopingPermission: Boolean = player.hasPermission(COPING)
-    def withCoping: Option[org.bukkit.entity.Player] = if (hasCopingPermission) Some(player) else None
+    def withCoping: Option[Player] = if (hasCopingPermission) Some(player) else None
 
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -5,7 +5,7 @@ import org.bukkit.scheduler.BukkitRunnable
 
 class Runner(player: Player)(implicit service: PhantomCopeService) extends BukkitRunnable {
   override def run(): Unit = {
-    import ImplicitConversions._
+    import Timer._
     player.deactivateCoping()
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -3,15 +3,14 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 import org.bukkit.persistence.PersistentDataType
 import collection.mutable.{Map => MutableMap}
 import Configure._
+import org.bukkit.entity.Player
 
 object Timer {
-  private type BukkitPlayer = org.bukkit.entity.Player
-
   val NAMESPACED_KEY = "timer"
   val DATA_TYPE: PersistentDataType[String, String] = PersistentDataType.STRING
-  val timers: collection.mutable.Map[BukkitPlayer, Runner] = MutableMap[BukkitPlayer, Runner]()
+  val timers: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
 
-  class Player(player: BukkitPlayer)(implicit service: PhantomCopeService) {
+  implicit class PlayerWithTimer(player: Player)(implicit service: PhantomCopeService) {
     private val container = player.getPersistentDataContainer
     private val namespacedKey = service.makeNamespacedKey(NAMESPACED_KEY)
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
@@ -1,6 +1,6 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{ImplicitConversions, PhantomCopeService}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
 import org.bukkit.entity.{Entity, Phantom, Player}
 import org.bukkit.entity.EntityType._
@@ -11,7 +11,7 @@ import scala.util.Try
 
 class EntityTargetEventListener(implicit service: PhantomCopeService) extends EventListener {
   import EntityTargetEventListener._
-  import ImplicitConversions._
+  import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Timer._
 
   @EventHandler
   def onEntityTarget(event: EntityTargetEvent): Unit = {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -1,6 +1,6 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Configure, PhantomCopeService}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
 import org.bukkit.Material
 import org.bukkit.event.EventHandler
@@ -29,9 +29,9 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 }
 
 object PlayerItemConsumeEventListener {
-  val TARGET_ITEM: Material = Material.ROTTEN_FLESH
+  import Configure._
   implicit class Item(item: ItemStack) {
-    def withTarget: Option[ItemStack] = if (item.getType == TARGET_ITEM) Some(item) else None
+    def withTarget(implicit service: PhantomCopeService): Option[ItemStack] = if (service.getTargetItems.contains(item.getType)) Some(item) else None
   }
   def toItem(item: ItemStack): Item = new Item(item)
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -1,6 +1,6 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{PhantomCopeService, ImplicitConversions}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
 import org.bukkit.Material
 import org.bukkit.event.EventHandler
@@ -12,7 +12,9 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
   @EventHandler
   def onPlayerItemConsume(event: PlayerItemConsumeEvent): Unit = {
-    import ImplicitConversions._
+    import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Permissions._
+    import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Timer._
+
     for {
       player <- event.getPlayer.withCoping
       item <- event.getItem.withTarget
@@ -28,8 +30,8 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
 object PlayerItemConsumeEventListener {
   val TARGET_ITEM: Material = Material.ROTTEN_FLESH
-  class Item(item: ItemStack) {
+  implicit class Item(item: ItemStack) {
     def withTarget: Option[ItemStack] = if (item.getType == TARGET_ITEM) Some(item) else None
   }
-  implicit def toItem(item: ItemStack): Item = new Item(item)
+  def toItem(item: ItemStack): Item = new Item(item)
 }


### PR DESCRIPTION
fix #5 

- `services.phantomCopeService.items`にString配列を指定することで指定できる
- `Material.valueOf`して変換して渡すので間違った名前を指定しても無視する
