### PR TITLE
#7 [PhantomCope] 無効有効時のメッセージをconfig.ymlで指定できるように

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,3 +7,6 @@ services:
     items:
       - ROTTEN_FLESH # ゾンビ肉
       - POISONOUS_POTATO # 青芋
+    messages:
+      activation: null
+      deactivation: null

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -23,5 +23,15 @@ object Configure {
      * 対象にするMaterialのリスト
      */
     def getTargetItems: List[Material] = configure.getStringList(makeKey("items")).asScala.flatMap(name => Try(Material.valueOf(name)).toOption).toList
+
+    /**
+     * 機能有効時に表示されるメッセージ
+     */
+    def getActivationMessage: Option[String] = Option(configure.getString(makeKey("messages.activation")))
+
+    /**
+     * 機能無効時に表示されるメッセージ
+     */
+    def getDeactivationMessage: Option[String] = Option(configure.getString(makeKey("messages.deactivation")))
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -29,7 +29,7 @@ object Timer {
       val runner = new Runner(player)
       timers += (player -> runner)
       runner.runTaskLaterAsynchronously(service.getPlugin, service.getActiveCopingTicks)
-      player.sendMessage(s"${player.getDisplayName} activate coping")
+      service.getActivationMessage.foreach(player.sendMessage)
     }
 
     /**
@@ -38,7 +38,7 @@ object Timer {
     def deactivateCoping(): Unit = {
       container.remove(namespacedKey)
       timers.get(player).foreach(_.cancel())
-      player.sendMessage(s"${player.getDisplayName} deactivate coping")
+      service.getDeactivationMessage.foreach(player.sendMessage)
     }
   }
 


### PR DESCRIPTION
fix #7

`messages.activation`, `messages.deactivation`でそれぞれ指定する
`null`突っ込んでおくとメッセージは送信されない