### PR TITLE
#13 [PhantomCope] Itemに対して有効Ticksを指定する

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,9 +4,9 @@ services:
   phantomCopeService:
     items:
       - name: ROTTEN_FLESH # ゾンビ肉
-        ticks: 1000
+        ticks: 1200 # 20tick/1s * 60s
       - name: POISONOUSE_POTATO # 青芋
-        ticks: 1000
+        ticks: 1200
     messages:
       activation: null
       deactivation: null

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,9 +4,9 @@ services:
   phantomCopeService:
     items:
       - name: ROTTEN_FLESH # ゾンビ肉
-        tick: 1000
+        ticks: 1000
       - name: POISONOUSE_POTATO # 青芋
-        tick: 1000
+        ticks: 1000
     messages:
       activation: null
       deactivation: null

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,8 +5,10 @@ services:
     # 効果が有効なTick数
     tick: 1000
     items:
-      - ROTTEN_FLESH # ゾンビ肉
-      - POISONOUS_POTATO # 青芋
+      - name: ROTTEN_FLESH # ゾンビ肉
+        tick: 1000
+      - name: POISONOUSE_POTATO # 青芋
+        tick: 1000
     messages:
       activation: null
       deactivation: null

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,8 +2,6 @@ services:
   # PhantomCopeService
   # ファントムの追跡から逃れるための機能まとめ
   phantomCopeService:
-    # 効果が有効なTick数
-    tick: 1000
     items:
       - name: ROTTEN_FLESH # ゾンビ肉
         tick: 1000

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -9,7 +9,7 @@ import scala.util.Try
 
 object Configure {
 
-  case class TargetItem(material: Material, tick: Long)
+  case class TargetItem(material: Material, ticks: Long)
 
   implicit class ServiceWithConfigure(service: PhantomCopeService) {
     private val configure = service.getPlugin.getConfig
@@ -26,9 +26,9 @@ object Configure {
           name <- map.get("name")
           name <- Try(name.asInstanceOf[String]).toOption
           material <- Try(Material.valueOf(name)).toOption
-          tick <- map.get("tick")
-          tick <- Try(tick.asInstanceOf[Long]).toOption
-        } yield TargetItem(material, tick)
+          ticks <- map.get("ticks")
+          ticks <- Try(ticks.asInstanceOf[Long]).toOption
+        } yield TargetItem(material, ticks)
       }).toList
     }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -10,6 +10,15 @@ import scala.util.Try
 object Configure {
 
   case class TargetItem(material: Material, ticks: Long)
+  object TargetItem {
+    def fromMap(map: mutable.Map[String, Any]): Option[TargetItem] = for {
+      name <- map.get("name")
+      name <- Try(name.asInstanceOf[String]).toOption
+      material <- Try(Material.valueOf(name)).toOption
+      ticks <- map.get("ticks")
+      ticks <- Try(ticks.asInstanceOf[Int]).toOption
+    } yield TargetItem(material, ticks.toLong)
+  }
 
   implicit class ServiceWithConfigure(service: PhantomCopeService) {
     private val configure = service.getPlugin.getConfig

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -28,18 +28,11 @@ object Configure {
     /**
      * 対象のTargetItemのリスト
      */
-    def getTargetItems: List[TargetItem] = {
-      configure.getMapList(makeKey("items")).asScala.map(_.asScala).flatMap(map => {
-        for {
-          map <- Try(map.asInstanceOf[mutable.Map[String, Any]]).toOption
-          name <- map.get("name")
-          name <- Try(name.asInstanceOf[String]).toOption
-          material <- Try(Material.valueOf(name)).toOption
-          ticks <- map.get("ticks")
-          ticks <- Try(ticks.asInstanceOf[Long]).toOption
-        } yield TargetItem(material, ticks)
-      }).toList
-    }
+    def getTargetItems: List[TargetItem] =
+      configure.getMapList(makeKey("items")).asScala.map(_.asScala).flatMap(map => for {
+        map <- Try(map.asInstanceOf[mutable.Map[String, Any]]).toOption
+        item <- TargetItem.fromMap(map)
+      } yield item).toList
 
     /**
      * 機能有効時に表示されるメッセージ

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -17,13 +17,7 @@ object Configure {
     private def makeKey(key: String): String = service.makeConfigurePath(key)
 
     /**
-     * 回避を開始して効果が無効になるまでの時間(tick)
-     * @return Long
-     */
-    def getActiveCopingTicks: Long = configure.getLong(makeKey("tick"), 1000)
-
-    /**
-     * 対象にするMaterialのリスト
+     * 対象のTargetItemのリスト
      */
     def getTargetItems: List[TargetItem] = {
       configure.getMapList(makeKey("items")).asScala.map(_.asScala).flatMap(map => {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -23,12 +23,12 @@ object Timer {
     /**
      * 追跡の回避を有効にする
      */
-    def activateCoping(tick: Long): Unit = {
+    def activateCoping(ticks: Long): Unit = {
       container.set(namespacedKey, DATA_TYPE, "*")
       timers.get(player).foreach(_.cancel())
       val runner = new Runner(player)
       timers += (player -> runner)
-      runner.runTaskLaterAsynchronously(service.getPlugin, tick)
+      runner.runTaskLaterAsynchronously(service.getPlugin, ticks)
       service.getActivationMessage.foreach(player.sendMessage)
     }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -23,12 +23,12 @@ object Timer {
     /**
      * 追跡の回避を有効にする
      */
-    def activateCoping(): Unit = {
+    def activateCoping(tick: Long = service.getActiveCopingTicks): Unit = {
       container.set(namespacedKey, DATA_TYPE, "*")
       timers.get(player).foreach(_.cancel())
       val runner = new Runner(player)
       timers += (player -> runner)
-      runner.runTaskLaterAsynchronously(service.getPlugin, service.getActiveCopingTicks)
+      runner.runTaskLaterAsynchronously(service.getPlugin, tick)
       service.getActivationMessage.foreach(player.sendMessage)
     }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -23,7 +23,7 @@ object Timer {
     /**
      * 追跡の回避を有効にする
      */
-    def activateCoping(tick: Long = service.getActiveCopingTicks): Unit = {
+    def activateCoping(tick: Long): Unit = {
       container.set(namespacedKey, DATA_TYPE, "*")
       timers.get(player).foreach(_.cancel())
       val runner = new Runner(player)

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -22,7 +22,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
       if (player.isSneaking) {
         player.deactivateCoping()
       } else {
-        player.activateCoping()
+        player.activateCoping(item.tick)
       }
     }
   }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -17,7 +17,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
     for {
       player <- event.getPlayer.withCoping
-      item <- event.getItem.withTarget
+      item <- event.getItem.toTargetItem
     } {
       if (player.isSneaking) {
         player.deactivateCoping()
@@ -30,8 +30,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
 object PlayerItemConsumeEventListener {
   import Configure._
-  implicit class Item(item: ItemStack) {
-    def withTarget(implicit service: PhantomCopeService): Option[ItemStack] = if (service.getTargetItems.contains(item.getType)) Some(item) else None
+  implicit class ItemStackExtends(itemStack: ItemStack)(implicit service: PhantomCopeService) {
+    def toTargetItem: Option[TargetItem] = service.getTargetItems.find(_.material == itemStack.getType)
   }
-  def toItem(item: ItemStack): Item = new Item(item)
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -22,7 +22,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
       if (player.isSneaking) {
         player.deactivateCoping()
       } else {
-        player.activateCoping(item.tick)
+        player.activateCoping(item.ticks)
       }
     }
   }


### PR DESCRIPTION
fix #13 

`services.phantomCopeService.items`に
```yml
- name: Material
  ticks: Int
```
で指定できる

有効状態での重ねがけには対応していない。