### PR TITLE
#19 アイテムの効果を無視できるように

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,3 +10,4 @@ services:
     messages:
       activation: null
       deactivation: null
+    ignore-item-effect: true # 消費したアイテムの本来の効果を無視する

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -43,5 +43,11 @@ object Configure {
      * 機能無効時に表示されるメッセージ
      */
     def getDeactivationMessage: Option[String] = Option(configure.getString(makeKey("messages.deactivation")))
+
+    /**
+     * itemの効果を無視するか
+     */
+    def isIgnoreItemEffect: Boolean = configure.getBoolean(makeKey("ignore-item-effect"), true)
+
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -2,9 +2,10 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Configure, PhantomCopeService}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
+import org.bukkit.GameMode
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerItemConsumeEvent
-import org.bukkit.inventory.{PlayerInventory, ItemStack}
+import org.bukkit.inventory.{ItemStack, PlayerInventory}
 
 class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) extends EventListener {
   import PlayerItemConsumeEventListener._
@@ -27,7 +28,12 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
       import Configure.ServiceWithConfigure
       if (service.isIgnoreItemEffect) {
-        decreaseAmount(event.getItem, player.getInventory)
+        /**
+         * クリエイティブモードでなければ減算させる
+         * スペクテイターモードの場合でも通ってしまうが、まずアイテムの消費がないので無視する
+         */
+        if (player.getGameMode != GameMode.CREATIVE) decreaseAmount(event.getItem, player.getInventory)
+
         event.setCancelled(true)
       }
     }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -25,6 +25,23 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
       } else {
         player.activateCoping(item.ticks)
       }
+
+      import Configure.ServiceWithConfigure
+      if (service.isIgnoreItemEffect) {
+        val item = event.getItem
+        item.setAmount(item.getAmount - 1)
+
+        /**
+         * プレイヤのインベントリに更新をかける
+         * 右手(MainHand)にあるアイテムが優先して消費されるはず
+         * Materialを比較して先に一致した方で更新する
+         */
+        val inventory = player.getInventory
+        if (item.getType == inventory.getItemInMainHand.getType) inventory.setItemInMainHand(item)
+        else if (item.getType == inventory.getItemInOffHand.getType) inventory.setItemInOffHand(item)
+
+        event.setCancelled(true)
+      }
     }
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -2,7 +2,6 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 
 import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Configure, PhantomCopeService}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
-import org.bukkit.Material
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerItemConsumeEvent
 import org.bukkit.inventory.ItemStack

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -17,8 +17,15 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
     import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.Permissions._
     import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Timer._
 
+    /**
+     * クリエイティブモードを除外する
+     * スペクテイターモードではアイテムの消費自体がないので無視する
+     * `cope`権限を持つユーザのみに作用する
+     * itemsに記述されたMaterialのみ対象にする
+     */
     for {
-      player <- event.getPlayer.withPermission(Cope)
+      player <- event.getPlayer.withoutCreativeMode
+      player <- player.withPermission(Cope)
       item <- event.getItem.toTargetItem
     } {
       if (player.isSneaking) {
@@ -30,11 +37,9 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
       import Configure.ServiceWithConfigure
       if (service.isIgnoreItemEffect) {
         /**
-         * クリエイティブモードでなければ減算させる
-         * スペクテイターモードの場合でも通ってしまうが、まずアイテムの消費がないので無視する
+         * インベントリからアイテムを探して減算する
          */
-        if (player.getGameMode != GameMode.CREATIVE) decreaseAmount(event.getItem, player.getInventory)
-
+        decreaseAmount(event.getItem, player.getInventory)
         /**
          * イベントをキャンセルすることで毒などの効果を無視する
          * 空腹度にも作用しない

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -4,7 +4,7 @@ import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Configure
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerItemConsumeEvent
-import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.{PlayerInventory, ItemStack}
 
 class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) extends EventListener {
   import PlayerItemConsumeEventListener._
@@ -27,18 +27,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
 
       import Configure.ServiceWithConfigure
       if (service.isIgnoreItemEffect) {
-        val item = event.getItem
-        item.setAmount(item.getAmount - 1)
-
-        /**
-         * プレイヤのインベントリに更新をかける
-         * 右手(MainHand)にあるアイテムが優先して消費されるはず
-         * Materialを比較して先に一致した方で更新する
-         */
-        val inventory = player.getInventory
-        if (item.getType == inventory.getItemInMainHand.getType) inventory.setItemInMainHand(item)
-        else if (item.getType == inventory.getItemInOffHand.getType) inventory.setItemInOffHand(item)
-
+        decreaseAmount(event.getItem, player.getInventory)
         event.setCancelled(true)
       }
     }
@@ -50,4 +39,16 @@ object PlayerItemConsumeEventListener {
   implicit class ItemStackExtends(itemStack: ItemStack)(implicit service: PhantomCopeService) {
     def toTargetItem: Option[TargetItem] = service.getTargetItems.find(_.material == itemStack.getType)
   }
+
+  /**
+   * プレイヤのインベントリに更新をかける
+   * 右手(MainHand)にあるアイテムが優先して消費されるはず
+   * Materialを比較して先に一致した方で更新する
+   */
+  def decreaseAmount(itemStack: ItemStack, inventory: PlayerInventory, count: Int = 1): Unit = {
+    itemStack.setAmount(itemStack.getAmount - count)
+    if (itemStack.getType == inventory.getItemInMainHand.getType) inventory.setItemInMainHand(itemStack)
+    else if (itemStack.getType == inventory.getItemInOffHand.getType) inventory.setItemInOffHand(itemStack)
+  }
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -3,6 +3,7 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
 import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.{Configure, PhantomCopeService}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
 import org.bukkit.GameMode
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.player.PlayerItemConsumeEvent
 import org.bukkit.inventory.{ItemStack, PlayerInventory}
@@ -48,6 +49,9 @@ object PlayerItemConsumeEventListener {
   import Configure._
   implicit class ItemStackExtends(itemStack: ItemStack)(implicit service: PhantomCopeService) {
     def toTargetItem: Option[TargetItem] = service.getTargetItems.find(_.material == itemStack.getType)
+  }
+  implicit class PlayerWithoutCreativeMode(player: Player) {
+    def withoutCreativeMode: Option[Player] = if (player.getGameMode == GameMode.CREATIVE) None else Some(player)
   }
 
   /**

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -34,6 +34,10 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
          */
         if (player.getGameMode != GameMode.CREATIVE) decreaseAmount(event.getItem, player.getInventory)
 
+        /**
+         * イベントをキャンセルすることで毒などの効果を無視する
+         * 空腹度にも作用しない
+         */
         event.setCancelled(true)
       }
     }


### PR DESCRIPTION
fix #19

イベントをキャンセルした上でスタックの量だけ減らすようにした
`ignore-item-effect`が有効の場合に作用する
