### PR TITLE
#22 アイテムの重ねがけができるように

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,6 @@ services:
       - name: POISONOUS_POTATO # 青芋
         ticks: 1200
     messages:
-      activation: null
+      activation: null # $ticks を有効時間に置き換える
       deactivation: null
     ignore-item-effect: true # 消費したアイテムの本来の効果を無視する

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
@@ -6,11 +6,11 @@ import Configure._
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils._
 import org.bukkit.entity.Player
 
-object Timer {
-  val NAMESPACED_KEY = "timer"
+object CopingEffect {
+  val NAMESPACED_KEY = "coping-effect"
   val DATA_TYPE: PersistentDataType[String, String] = PersistentDataType.STRING
 
-  implicit class PlayerWithTimer(player: Player)(implicit service: PhantomCopeService) {
+  implicit class PlayerWithCopingEffect(player: Player)(implicit service: PhantomCopeService) {
     private val container = player.getPersistentDataContainer
     private val namespacedKey = service.makeNamespacedKey(NAMESPACED_KEY)
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
@@ -20,11 +20,15 @@ object CopingEffect {
      */
     def canCope: Boolean = container.has(namespacedKey, DATA_TYPE)
 
+    def setKey(): Unit = container.set(namespacedKey, DATA_TYPE, "*")
+
+    def removeKey(): Unit = container.remove(namespacedKey)
+
     /**
      * 追跡の回避を有効にする
      */
     def activateCoping(ticks: Long): Unit = {
-      container.set(namespacedKey, DATA_TYPE, "*")
+      setKey()
       Runner.start(player, ticks)
       service.getActivationMessage.foreach(player.sendServiceMessage)
     }
@@ -33,7 +37,7 @@ object CopingEffect {
      * 追跡の回避を無効にする
      */
     def deactivateCoping(): Unit = {
-      container.remove(namespacedKey)
+      removeKey()
       if (!Runner.stop(player))
         service.getDeactivationMessage.foreach(player.sendServiceMessage)
     }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
@@ -34,8 +34,8 @@ object CopingEffect {
      */
     def deactivateCoping(): Unit = {
       container.remove(namespacedKey)
-      Runner.stop(player)
-      service.getDeactivationMessage.foreach(player.sendServiceMessage)
+      if (!Runner.stop(player))
+        service.getDeactivationMessage.foreach(player.sendServiceMessage)
     }
   }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/CopingEffect.scala
@@ -29,8 +29,8 @@ object CopingEffect {
      */
     def activateCoping(ticks: Long): Unit = {
       setKey()
-      Runner.start(player, ticks)
-      service.getActivationMessage.foreach(player.sendServiceMessage)
+      val effectiveTicks = Runner.start(player, ticks)
+      service.getActivationMessage.foreach(message => player.sendServiceMessage(message.replace("$ticks", effectiveTicks.toString)))
     }
 
     /**

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -34,7 +34,7 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
 }
 
 object Runner {
-  val runners: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
+  private val runners: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
 
   def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = new Runner(player, effectiveTicks)(service)
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -6,9 +6,6 @@ import org.bukkit.scheduler.BukkitRunnable
 class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService) extends BukkitRunnable {
   private var spentTicks = 0L
 
-  // 毎Tick呼び出す
-  runTaskTimer(service.getPlugin, 0L, 1L)
-
   override def run(): Unit = {
     import Timer._
     spentTicks += 1
@@ -22,6 +19,13 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
   }
 
   def getSpentTicks: Long = spentTicks
+
+  def start(): (Player, Runner) = {
+    // 毎Tick呼び出す
+    runTaskTimer(service.getPlugin, 0L, 1L)
+    player -> this
+  }
+
 }
 
 object Runner {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -35,7 +35,7 @@ object Runner {
         runner.getRemainingTicks
       case None => 0L
     }
-    new Runner(player, spentTicks + effectiveTicks)(service)
+    new Runner(player, spentTicks + effectiveTicks)
   }
   
   def start(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Unit = {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -51,6 +51,6 @@ object Runner {
   }
 
   // プレイヤからrunnerを探して停止させる
-  def stop(player: Player): Unit = runners.find(_._1 == player).foreach(_._2.stop())
+  def stop(player: Player): Unit = runners.get(player).foreach(_.stop())
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -37,11 +37,15 @@ object Runner {
     }
     new Runner(player, spentTicks + effectiveTicks)
   }
-  
-  def start(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Unit = {
+
+  /**
+   * 有効時間(ticks)を返す
+   */
+  def start(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Long = {
     val runner = Runner(player, effectiveTicks)
     runner.runTaskTimer(service.getPlugin, 0L, 1L)
     runners += (player -> runner)
+    runner.getRemainingTicks
   }
 
   // プレイヤからrunnerを探して停止させる

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -25,7 +25,7 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
   }
 
   def stop(): Unit = {
-    import Timer._
+    import CopingEffect._
     player.deactivateCoping()
     runners.remove(player)
     cancel()

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -36,6 +36,18 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
 object Runner {
   private val runners: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
 
-  def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = new Runner(player, effectiveTicks)(service)
+  def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = {
+    /**
+     * 前に実行されていたものがあるかチェックする
+     * あればstopして、経過時間を返す
+     */
+    val spentTicks = runners.get(player) match {
+      case Some(runner) =>
+        runner.stop()
+        runner.getRemainingTicks
+      case None => 0L
+    }
+    new Runner(player, spentTicks + effectiveTicks)(service)
+  }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -49,6 +49,10 @@ object Runner {
     }
     new Runner(player, spentTicks + effectiveTicks)(service)
   }
+  
+  def start(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Unit = {
+    Runner(player, effectiveTicks).start()
+  }
 
   // プレイヤからrunnerを探して停止させる
   def stop(player: Player): Boolean = runners.get(player) match {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -51,7 +51,7 @@ object Runner {
     else {
       runner.foreach(_.cancel())
       runners.remove(player)
-      player.deactivateCoping()
+      player.removeKey()
       true
     }
   }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -2,8 +2,11 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
 import org.bukkit.entity.Player
 import org.bukkit.scheduler.BukkitRunnable
+import collection.mutable.{Map => MutableMap}
 
 class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService) extends BukkitRunnable {
+  import Runner._
+
   private var spentTicks = 0L
 
   override def run(): Unit = {
@@ -13,22 +16,23 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
     // 有効時間を経過
     if (spentTicks > effectiveTicks) {
       player.deactivateCoping()
-      Timer.timers.remove(player)
+      runners.remove(player)
       cancel()
     }
   }
 
   def getSpentTicks: Long = spentTicks
 
-  def start(): (Player, Runner) = {
+  def start(): Unit = {
     // 毎Tick呼び出す
     runTaskTimer(service.getPlugin, 0L, 1L)
-    player -> this
+    runners += (player -> this)
   }
 
 }
 
 object Runner {
+  val runners: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
 
   def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = new Runner(player, effectiveTicks)(service)
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -45,15 +45,12 @@ object Runner {
   }
 
   // プレイヤからrunnerを探して停止させる
-  def stop(player: Player)(implicit service: PhantomCopeService): Boolean = {
-    val runner = runners.get(player)
-    if (runner.isEmpty) false
-    else {
-      runner.foreach(_.cancel())
-      runners.remove(player)
+  def stop(player: Player)(implicit service: PhantomCopeService): Boolean = runners.remove(player) match {
+    case Some(runner) =>
+      runner.cancel()
       player.removeKey()
       true
-    }
+    case None => false
   }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -3,9 +3,23 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 import org.bukkit.entity.Player
 import org.bukkit.scheduler.BukkitRunnable
 
-class Runner(player: Player)(implicit service: PhantomCopeService) extends BukkitRunnable {
+class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService) extends BukkitRunnable {
+  private var spentTicks = 0L
+
+  // 毎Tick呼び出す
+  runTaskTimer(service.getPlugin, 0L, 1L)
+
   override def run(): Unit = {
     import Timer._
-    player.deactivateCoping()
+    spentTicks += 1
+
+    // 有効時間を経過
+    if (spentTicks > effectiveTicks) {
+      player.deactivateCoping()
+      Timer.timers.remove(player)
+      cancel()
+    }
   }
+
+  def getSpentTicks: Long = spentTicks
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -18,12 +18,6 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
 
   def getRemainingTicks: Long = effectiveTicks - spentTicks
 
-  def start(): Unit = {
-    // 毎Tick呼び出す
-    runTaskTimer(service.getPlugin, 0L, 1L)
-    runners += (player -> this)
-  }
-
   def stop(): Unit = {
     import CopingEffect._
     player.deactivateCoping()
@@ -51,7 +45,9 @@ object Runner {
   }
   
   def start(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Unit = {
-    Runner(player, effectiveTicks).start()
+    val runner = Runner(player, effectiveTicks)
+    runner.runTaskTimer(service.getPlugin, 0L, 1L)
+    runners += (player -> runner)
   }
 
   // プレイヤからrunnerを探して停止させる

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -10,15 +10,10 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
   private var spentTicks = 0L
 
   override def run(): Unit = {
-    import Timer._
     spentTicks += 1
 
     // 有効時間を経過
-    if (spentTicks > effectiveTicks) {
-      player.deactivateCoping()
-      runners.remove(player)
-      cancel()
-    }
+    if (spentTicks > effectiveTicks) stop()
   }
 
   def getSpentTicks: Long = spentTicks
@@ -27,6 +22,13 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
     // 毎Tick呼び出す
     runTaskTimer(service.getPlugin, 0L, 1L)
     runners += (player -> this)
+  }
+
+  def stop(): Unit = {
+    import Timer._
+    player.deactivateCoping()
+    runners.remove(player)
+    cancel()
   }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -27,11 +27,11 @@ object Runner {
   def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = {
     /**
      * 前に実行されていたものがあるかチェックする
-     * あればstopして、経過時間を返す
+     * あればcancelして、経過時間を返す
      */
-    val spentTicks = runners.get(player) match {
+    val spentTicks = runners.remove(player) match {
       case Some(runner) =>
-        stop(player)
+        runner.cancel()
         runner.getRemainingTicks
       case None => 0L
     }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -51,6 +51,9 @@ object Runner {
   }
 
   // プレイヤからrunnerを探して停止させる
-  def stop(player: Player): Unit = runners.get(player).foreach(_.stop())
+  def stop(player: Player): Boolean = runners.get(player) match {
+    case Some(runner) => runner.stop(); true
+    case None => false
+  }
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -23,3 +23,9 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
 
   def getSpentTicks: Long = spentTicks
 }
+
+object Runner {
+
+  def apply(player: Player, effectiveTicks: Long)(implicit service: PhantomCopeService): Runner = new Runner(player, effectiveTicks)(service)
+
+}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -16,7 +16,7 @@ class Runner(player: Player, effectiveTicks: Long)(implicit service: PhantomCope
     if (spentTicks > effectiveTicks) stop()
   }
 
-  def getSpentTicks: Long = spentTicks
+  def getRemainingTicks: Long = effectiveTicks - spentTicks
 
   def start(): Unit = {
     // 毎Tick呼び出す

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Runner.scala
@@ -50,4 +50,7 @@ object Runner {
     new Runner(player, spentTicks + effectiveTicks)(service)
   }
 
+  // プレイヤからrunnerを探して停止させる
+  def stop(player: Player): Unit = runners.find(_._1 == player).foreach(_._2.stop())
+
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -2,7 +2,6 @@ package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
 import org.bukkit.persistence.PersistentDataType
 
-import collection.mutable.{Map => MutableMap}
 import Configure._
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils._
 import org.bukkit.entity.Player
@@ -10,7 +9,6 @@ import org.bukkit.entity.Player
 object Timer {
   val NAMESPACED_KEY = "timer"
   val DATA_TYPE: PersistentDataType[String, String] = PersistentDataType.STRING
-  val timers: collection.mutable.Map[Player, Runner] = MutableMap[Player, Runner]()
 
   implicit class PlayerWithTimer(player: Player)(implicit service: PhantomCopeService) {
     private val container = player.getPersistentDataContainer
@@ -27,10 +25,7 @@ object Timer {
      */
     def activateCoping(ticks: Long): Unit = {
       container.set(namespacedKey, DATA_TYPE, "*")
-      timers.get(player).foreach(_.cancel())
-      val runner = new Runner(player)
-      timers += (player -> runner)
-      runner.runTaskLaterAsynchronously(service.getPlugin, ticks)
+      Runner(player, ticks).start()
       service.getActivationMessage.foreach(player.sendServiceMessage)
     }
 
@@ -39,7 +34,7 @@ object Timer {
      */
     def deactivateCoping(): Unit = {
       container.remove(namespacedKey)
-      timers.get(player).foreach(_.cancel())
+      Runner.stop(player)
       service.getDeactivationMessage.foreach(player.sendServiceMessage)
     }
   }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Timer.scala
@@ -25,7 +25,7 @@ object Timer {
      */
     def activateCoping(ticks: Long): Unit = {
       container.set(namespacedKey, DATA_TYPE, "*")
-      Runner(player, ticks).start()
+      Runner.start(player, ticks)
       service.getActivationMessage.foreach(player.sendServiceMessage)
     }
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/EntityTargetEventListener.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 
 class EntityTargetEventListener(implicit service: PhantomCopeService) extends EventListener {
   import EntityTargetEventListener._
-  import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Timer._
+  import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.CopingEffect._
 
   @EventHandler
   def onEntityTarget(event: EntityTargetEvent): Unit = {

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/PlayerItemConsumeEventListener.scala
@@ -15,7 +15,7 @@ class PlayerItemConsumeEventListener(implicit service: PhantomCopeService) exten
   def onPlayerItemConsume(event: PlayerItemConsumeEvent): Unit = {
     import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Permissions._
     import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.Permissions._
-    import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Timer._
+    import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.CopingEffect._
 
     /**
      * クリエイティブモードを除外する


### PR DESCRIPTION
fix #22 

- `Runner`を毎Tick更新して利用
- object `Runner`に管理させる
- `Timer`がTimerしていなかったので命名変更
- start時に有効時間を表示できるようにした `$ticks` を `messages.activation`に書いておくと置換される
