### PR TITLE
#40 屋内でファントムが湧かないように

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,8 @@ services:
       activation: null # $ticks を有効時間に置き換える
       deactivation: null
     ignore-item-effect: true # 消費したアイテムの本来の効果を無視する
+    cancel-indoor: true # 屋内でのスポーンをキャンセルするか
+    max-altitude: 256 # 屋内かの判定を高度どこまで行うか
 
   # DragonHeadService
   dragon-head:

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -49,5 +49,15 @@ object Configure {
      */
     def isIgnoredItemEffect: Boolean = configure.getBoolean(makeKey("ignore-item-effect"), true)
 
+    /**
+     * ファントムを屋内で沸かせない（ガラスの下だと湧いてしまうので）
+     */
+    def isCancelingSpawningPhantomIndoor: Boolean = configure.getBoolean("cancel-indoor", true)
+
+    /**
+     * 屋内かの検索をかける最大高度
+     */
+    def getMaxAltitude: Int = configure.getInt("max-altitude", 256)
+
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/Configure.scala
@@ -52,12 +52,12 @@ object Configure {
     /**
      * ファントムを屋内で沸かせない（ガラスの下だと湧いてしまうので）
      */
-    def isCancelingSpawningPhantomIndoor: Boolean = configure.getBoolean("cancel-indoor", true)
+    def isCancelingSpawningPhantomIndoor: Boolean = configure.getBoolean(makeKey("cancel-indoor"), true)
 
     /**
      * 屋内かの検索をかける最大高度
      */
-    def getMaxAltitude: Int = configure.getInt("max-altitude", 256)
+    def getMaxAltitude: Int = configure.getInt(makeKey("max-altitude"), 256)
 
   }
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/PhantomCopeService.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/PhantomCopeService.scala
@@ -1,6 +1,6 @@
 package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping
 
-import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners.{EntityTargetEventListener, PlayerItemConsumeEventListener}
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners.{CreatureSpawnEventListener, EntityTargetEventListener, PlayerItemConsumeEventListener}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.{EventListener, Service}
 import dev.ekuinox.IntegrativeYmzeServerPlugin.{Main => Plugin}
 
@@ -17,7 +17,8 @@ class PhantomCopeService(implicit plugin: Plugin) extends Service {
   // このクラスで利用するListener
   override val eventListeners = Seq(
     new PlayerItemConsumeEventListener,
-    new EntityTargetEventListener
+    new EntityTargetEventListener,
+    new CreatureSpawnEventListener
   )
 
 }

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
@@ -13,6 +13,9 @@ class CreatureSpawnEventListener(implicit service: PhantomCopeService) extends E
 
   @EventHandler
   def onCreatureSpawn(event: CreatureSpawnEvent): Unit = {
+    // 機能が有効でない場合蹴る
+    if (!service.isCancelingSpawningPhantomIndoor) return
+
     // ファントムじゃない場合蹴る
     if (event.getEntity.getType != EntityType.PHANTOM) return
 

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
@@ -1,0 +1,40 @@
+package dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.listeners
+
+import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.PhantomCopeService
+import dev.ekuinox.IntegrativeYmzeServerPlugin.utils.EventListener
+import org.bukkit.block.Block
+import org.bukkit.entity.EntityType
+import org.bukkit.event.EventHandler
+import org.bukkit.event.entity.CreatureSpawnEvent
+
+class CreatureSpawnEventListener(implicit service: PhantomCopeService) extends EventListener {
+  import CreatureSpawnEventListener._
+
+  @EventHandler
+  def onCreatureSpawn(event: CreatureSpawnEvent): Unit = {
+    // ファントムじゃない場合蹴る
+    if (event.getEntity.getType != EntityType.PHANTOM) return
+
+    // 屋内の場合キャンセルする
+    if (event.getLocation.getBlock.isIndoor()) {
+      event.setCancelled(true)
+    }
+
+  }
+
+}
+
+object CreatureSpawnEventListener {
+
+  implicit class BlockExtended(block: Block) {
+    // 屋内のブロックか
+    def isIndoor(maxY: Int = 256): Boolean = {
+      for (i <- 0 until maxY - block.getY) {
+        val targetBlock = block.getRelative(0, i, 0)
+        if (!targetBlock.getType.isAir) return true
+      }
+      false
+    }
+  }
+
+}

--- a/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
+++ b/src/main/scala/dev/ekuinox/IntegrativeYmzeServerPlugin/services/phantomcoping/listeners/CreatureSpawnEventListener.scala
@@ -9,6 +9,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent
 
 class CreatureSpawnEventListener(implicit service: PhantomCopeService) extends EventListener {
   import CreatureSpawnEventListener._
+  import dev.ekuinox.IntegrativeYmzeServerPlugin.services.phantomcoping.Configure._
 
   @EventHandler
   def onCreatureSpawn(event: CreatureSpawnEvent): Unit = {
@@ -16,7 +17,7 @@ class CreatureSpawnEventListener(implicit service: PhantomCopeService) extends E
     if (event.getEntity.getType != EntityType.PHANTOM) return
 
     // 屋内の場合キャンセルする
-    if (event.getLocation.getBlock.isIndoor()) {
+    if (event.getLocation.getBlock.isIndoor(service.getMaxAltitude)) {
       event.setCancelled(true)
     }
 


### PR DESCRIPTION
fix #40

天井がガラスの場合にファントムが湧いちゃうのを抑制した

- スポーンした位置から上をループでチェックしていくだけ
- `cancel-indoor`が`true`の場合に機能
- `max-altitude`で指定した値の高さまでチェックを行う
